### PR TITLE
fix timepicker default value

### DIFF
--- a/Resources/public/js/script.js
+++ b/Resources/public/js/script.js
@@ -536,7 +536,8 @@ function initTimePicker() {
     if($('.form_timepicker').length > 0) {
         $(".form_timepicker").timepicker({
             'showMeridian': false,
-            'minuteStep': 1
+            'minuteStep': 1,
+            'defaultTime': 'value'
         });
     }
 }


### PR DESCRIPTION
Fixes the default value, if there was a previous value use that one and not the current time.
