### PR TITLE
Fix reset pwd confirmation link in mail

### DIFF
--- a/Resources/views/Resetting/reset_content.html.twig
+++ b/Resources/views/Resetting/reset_content.html.twig
@@ -1,4 +1,3 @@
-{% form_theme form theme %}
 <form action="{{ path('fos_user_resetting_reset', {'token': token}) }}" {{ form_enctype(form) }} method="POST" class="fos_user_resetting_reset">
     {{ form_widget(form) }}
     <div class="actions">


### PR DESCRIPTION
removing this line resolves an error when clicking on the confirmation link in the reset password e-mail
