### PR TITLE
Fix backend form layout

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -37,9 +37,9 @@
 
 {% block form_row %}
     {% spaceless %}
-        <div class="control-group{% if errors|length > 0 %} error{% endif %}">
+        <div class="input_prop{% if errors|length > 0 %} error{% endif %}">
             {{ form_label(form) }}
-            <div class="controls">
+            <div class="input">
                 {{ form_widget(form) }}
                 {% if max_length %}
                     <style>


### PR DESCRIPTION
@Mopster using input_prop class, we use this on other locations too and its not too small, the media field also uses this width, see #186 
