### PR TITLE
Make it configurable to show the topmenu in sidebar

### DIFF
--- a/Helper/Menu/TopMenuItem.php
+++ b/Helper/Menu/TopMenuItem.php
@@ -8,4 +8,26 @@ namespace Kunstmaan\AdminBundle\Helper\Menu;
 class TopMenuItem extends MenuItem
 {
 
+    /**
+     * @var boolean
+     */
+    private $appearInSidebar = false;
+
+    /**
+     * @param boolean $appearInSidebar
+     */
+    public function setAppearInSidebar($appearInSidebar)
+    {
+        $this->appearInSidebar = $appearInSidebar;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getAppearInSidebar()
+    {
+        return $this->appearInSidebar;
+    }
+
 }

--- a/Resources/views/Default/sidebar.html.twig
+++ b/Resources/views/Default/sidebar.html.twig
@@ -18,9 +18,18 @@
         <div class="tree clearfix">
             {% set currentMenuItem = adminmenu.current %}
    	        <ul>
+                {% if lowestTopChild.appearInSidebar %}
+                    <li class="jstree-open {% if lowestTopChild.internalname == currentMenuItem.internalname %}active{% endif %}" {% if lowestTopChild.role %} rel="{{lowestTopChild.role}}" {% endif %}>
+                        <a href="{{ path(lowestTopChild.route, lowestTopChild.routeparams) }}">{{ lowestTopChild.internalname | trans }}</a>
+                        <ul>
+                {% endif %}
                 {% for menuitem in navigationChildren %}
                     {% include 'KunstmaanAdminBundle:Default:rectreeview.html.twig' %}
                 {% endfor %}
+                {% if lowestTopChild.appearInSidebar %}
+                        </ul>
+                    </li>
+                {% endif %}
             </ul>
         </div>
     </aside>


### PR DESCRIPTION
Sometimes it may be good to show the topmenu item in the sidebar …
especially if you manage multiple websites in one backend, so that you
know which website you are currently editing.
