### PR TITLE
password not blank validation only on Registration

### DIFF
--- a/Controller/SettingsController.php
+++ b/Controller/SettingsController.php
@@ -80,7 +80,7 @@ class SettingsController extends Controller
         $em = $this->getDoctrine()->getManager();
         $request = $this->getRequest();
         $user = new User();
-        $form = $this->createForm(new UserType(), $user, array('password_required' => true));
+        $form = $this->createForm(new UserType(), $user, array('password_required' => true, 'validation_groups' => array('Registration')));
 
         if ('POST' == $request->getMethod()) {
             $form->bind($request);
@@ -126,6 +126,7 @@ class SettingsController extends Controller
 
         if ('POST' == $request->getMethod()) {
             $form->bind($request);
+
             if ($form->isValid()) {
                 if ($user->getPlainpassword() != "") {
                     $manipulator = $this->get('fos_user.util.user_manipulator');

--- a/Entity/User.php
+++ b/Entity/User.php
@@ -101,7 +101,7 @@ class User extends AbstractUser
     public static function loadValidatorMetadata(ClassMetadata $metadata)
     {
         $metadata->addPropertyConstraint('username', new NotBlank());
-        $metadata->addPropertyConstraint('plainPassword', new NotBlank());
+        $metadata->addPropertyConstraint('plainPassword', new NotBlank(array("groups" => array("Registration"))));
         $metadata->addPropertyConstraint('email', new NotBlank());
         $metadata->addPropertyConstraint('email', new Email());
         $metadata->addConstraint(new UniqueEntity(array(


### PR DESCRIPTION
Only apply the 'not blank validation' when adding a user, otherwise you cannot edit a user without typing in a password.
