### PR TITLE
Fix for duplicate role name

### DIFF
--- a/Entity/Role.php
+++ b/Entity/Role.php
@@ -26,7 +26,6 @@ class Role implements RoleInterface
 
     /**
      * @ORM\Column(type="string", name="role", unique=true, length=70)
-     *
      * @NotBlank()
      */
     protected $role;


### PR DESCRIPTION
When creating a new role with a name already in use, it will not throw a prettier error message, and not a sql error.
