### PR TITLE
changed method addViolationAtSubPath into  addViolationAt

### DIFF
--- a/Entity/Group.php
+++ b/Entity/Group.php
@@ -243,7 +243,7 @@ class Group implements RoleInterface, GroupInterface
     public function isGroupValid(ExecutionContext $context)
     {
         if (!(count($this->getRoles()) > 0)) {
-            $context->addViolationAtSubPath('rolesCollection', 'At least one option must be selected.', array(), null);
+            $context->addViolationAt('rolesCollection', 'At least one option must be selected.', array(), null);
         }
     }
 }


### PR DESCRIPTION
addViolationAtSubPath is removed in 2.3 and now we must use addViolationAt to show the error message. Else we see a blank page when trying to save a group without any roles selected.
