### PR TITLE
make it possible to hide form label

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -26,10 +26,12 @@
         {% if required %}
             {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
         {% endif %}
-        {% if label is empty %}
-            {% set label = name|humanize %}
+        {% if label is not sameas(false) %}
+            {% if label is empty %}
+                {% set label = name|humanize %}
+            {% endif %}
+            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}{% if required %} *{% endif %}</label>
         {% endif %}
-        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}{% if required %} *{% endif %}</label>
     {% endspaceless %}
 {% endblock form_label %}
 


### PR DESCRIPTION
Make our admin label form widget compatible with the existing sf options:
https://github.com/symfony/symfony/commit/36e455680549bfe9fa5b1282e95bb9b36f2220be#src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
