### PR TITLE
Added XML support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('kuma_admin');
 
         $rootNode
+            ->fixXmlConfig('admin_locale')
             ->children()
                 ->scalarNode('dashboard_route')->end()
 

--- a/DependencyInjection/KunstmaanAdminExtension.php
+++ b/DependencyInjection/KunstmaanAdminExtension.php
@@ -75,4 +75,20 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $configs = $container->getExtensionConfig($this->getAlias());
         $this->processConfiguration(new Configuration(), $configs);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNamespace()
+    {
+        return 'http://bundles.kunstmaan.be/schema/dic/admin';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getXsdValidationBasePath()
+    {
+        return __DIR__.'/../Resources/config/schema';
+    }
 }

--- a/Resources/config/schema/admin-1.0.xsd
+++ b/Resources/config/schema/admin-1.0.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema xmlns="http://bundles.kunstmaan.be/schema/dic/admin"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://bundles.kunstmaan.be/schema/dic/admin"
+    elementFormDefault="qualified">
+
+    <xsd:element name="config" type="config" />
+
+    <xsd:complexType name="config">
+        <xsd:sequence>
+            <xsd:element name="admin-locale" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+
+        <xsd:attribute name="admin-locale" type="xsd:string" />
+        <xsd:attribute name="default-admin-locale" type="xsd:string" />
+    </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
This PR adds XML support for the bundle configuration. If you want, I
can add some tests using the Symfony CMF Testing component and
MatthiasSymfonyDependencyInjectionTest package to verify you fully
support all config formats.
