### PR TITLE
Fix superadmin group

### DIFF
--- a/DataFixtures/ORM/GroupFixtures.php
+++ b/DataFixtures/ORM/GroupFixtures.php
@@ -30,10 +30,17 @@ class GroupFixtures extends AbstractFixture implements OrderedFixtureInterface
             $this->getReference('guest-role')
         ));
 
+        $group3 = $this->createGroup($manager, 'Super administrators', array(
+            $this->getReference('permissionmanager-role'),
+            $this->getReference('superadmin-role'),
+            $this->getReference('admin-role'),
+        ));
+
         $manager->flush();
 
-        $this->addReference('admins-group', $group1);
-        $this->addReference('guests-group', $group2);
+        $this->addReference('admins-group',       $group1);
+        $this->addReference('guests-group',       $group2);
+        $this->addReference('superadmins-group',  $group3);
     }
 
     /**

--- a/DataFixtures/ORM/UserFixtures.php
+++ b/DataFixtures/ORM/UserFixtures.php
@@ -43,7 +43,7 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface, C
             'admin@domain.com',
             $this->container->getParameter('kuma_admin.default_admin_locale'),
             array('ROLE_SUPER_ADMIN'),
-            array($manager->merge($this->getReference('admins-group'))),
+            array($manager->merge($this->getReference('superadmins-group'))),
             true
         );
         $manager->flush();


### PR DESCRIPTION
The superadmin group wasn't defined in the fixtures so you couldn't add a new superadmin user without creating the group first.
