### PR TITLE
Remove redundancy

### DIFF
--- a/DataFixtures/ORM/GroupFixtures.php
+++ b/DataFixtures/ORM/GroupFixtures.php
@@ -55,7 +55,6 @@ class GroupFixtures extends AbstractFixture implements OrderedFixtureInterface
     private function createGroup(ObjectManager $manager, $name, array $roles = array())
     {
         $group = new Group($name);
-        $group->setName($name);
         foreach ($roles as $role) {
             $group->addRole($role);
         }


### PR DESCRIPTION
The Constructor of the Group Entity already receives the name and does:
$this->name = $name
Calling $group->setName is redundant
