### PR TITLE
Update guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "knplabs/knp-menu-bundle": "~2.0",
         "sensio/framework-extra-bundle": "*",
         "kunstmaan/utilities-bundle": "~3.0.0",
-        "guzzle/guzzle": "3.8.*"
+        "guzzle/guzzle": "~3.8"
     },
     "suggests": {
         "kunstmaan/user-management-bundle": "~3.0.0"


### PR DESCRIPTION
We tried to use https://packagist.org/packages/bradfeehan/desk-php (using guzzle 3.9) but composer failed.
