### PR TITLE
fixes double click prevention breaking "save as draft" button

### DIFF
--- a/Resources/public/js/script.js
+++ b/Resources/public/js/script.js
@@ -440,8 +440,14 @@ function initCustomSelect() {
 
 //Custom Select
 function initDisableButtonsOnSubmit() {
+    var formSubmitting = false;
     $("#pageadminform").submit(function(){
-        $(".main_actions").find("button, a").attr('disabled','disabled').addClass("disabled");
+        if (formSubmitting) {
+            return false;
+        }
+
+        formSubmitting = true;
+        $(".main_actions").find("button, a").attr('data-toggle', null).addClass("disabled");
     });
 }
 


### PR DESCRIPTION
Setting `disabled=disabled` on the "Save as draft" button prevents submitting the "saveasdraft" parameter.

This also unsets `data-toggle=modal` on "Publish/Unpublish" and "Add subpage" links, just in case.