### PR TITLE
Fixing shortcut for ALT key

### DIFF
--- a/Resources/ui/js/_page-editor.js
+++ b/Resources/ui/js/_page-editor.js
@@ -319,7 +319,7 @@ kunstmaanbundles.pageEditor = (function(window, undefined) {
     // Key Combinations
     keyCombinations = function() {
         $(document).on('keydown', function(e) {
-            if((e.ctrlKey || e.metaKey) && e.which === 83) {
+            if((e.ctrlKey || e.metaKey) && e.which === 83 && !e.altKey) {
                 e.preventDefault();
 
                 kunstmaanbundles.appLoading.addLoading();


### PR DESCRIPTION
There was a problem with polish ś (ALT + S) letter on windows machines which trigger save node action.

Shortcut code (e.which) was the same for CTRL + S , and ALT + S
